### PR TITLE
Fix invalid submodule link

### DIFF
--- a/content/en/zdoc/gettingstarted/installation.md
+++ b/content/en/zdoc/gettingstarted/installation.md
@@ -34,7 +34,7 @@ Go to your site root folder(`mydocs` folder in my case) and type the bellow.
 ```
 cd mydocs
 git init
-git submodule add https://github.com/zzossig/hugo-theme-zzo.git themes/zdoc
+git submodule add https://github.com/zzossig/hugo-theme-zdoc.git themes/zdoc
 ```
 
 ## Step 4: Add Config Files


### PR DESCRIPTION
In this PR, we are updating the submodule link when installing the zdoc theme for a hugo site.