### PR TITLE
Change heading from  'custom css' to 'custom font'

### DIFF
--- a/content/en/zzo/customization/customfont.md
+++ b/content/en/zzo/customization/customfont.md
@@ -24,7 +24,7 @@ enableToc: false
     - `"\"Source Sans Pro\", sans-serif"`
     - `"\"League Gothic\", sans-serif"`
 
-## Using custom css
+## Using custom font
 
 1. Add custom css file
 


### PR DESCRIPTION
Hey, I think this was instruction to add/use custom font. Hence the heading should be **Using custom font**.